### PR TITLE
Fix: Update GitHub Actions workflows to use self-hosted runner group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: 
+    runs-on:
       group: self-hosted
 
     strategy:
@@ -47,7 +47,8 @@ jobs:
           fail_ci_if_error: false
 
   docker-build:
-    runs-on: self-hosted
+    runs-on:
+      group: self-hosted
     needs: test
 
     steps:


### PR DESCRIPTION
## Summary

Update GitHub Actions workflows to consistently use the `group: self-hosted` format for all runner configurations.

## Changes

### CI Workflow Updates
- **Docker-build job**: Updated `runs-on` from `self-hosted` to `group: self-hosted` format
- **Consistent configuration**: Both test and docker-build jobs now use the same runner group format
- **Maintains compatibility**: Ensures proper runner group assignment and scheduling

### Workflow Configuration
Both workflows now use the standardized runner group format:
```yaml
runs-on:
  group: self-hosted
```

## Benefits

- **Consistent runner assignment** across all workflow jobs
- **Proper runner group utilization** for better resource management
- **Improved workflow reliability** with standardized configuration
- **Future-proof configuration** following GitHub Actions best practices

## Test Plan

- [x] CI workflow uses consistent runner group format
- [x] PR title check workflow uses runner group format
- [x] Both workflows maintain all existing functionality
- [x] YAML formatting is valid and consistent

This ensures all GitHub Actions jobs are properly assigned to the self-hosted runner group.