### PR TITLE
fix: configure E2E tests to use port 3003 in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:ci": "next dev -p 3003",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:3000',
+    baseURL: process.env.CI ? 'http://localhost:3003' : 'http://localhost:3000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -77,8 +77,8 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run dev',
-    url: 'http://localhost:3000',
+    command: process.env.CI ? 'npm run dev:ci' : 'npm run dev',
+    url: process.env.CI ? 'http://localhost:3003' : 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',
     stderr: 'pipe',


### PR DESCRIPTION
## Summary

• Configure E2E tests to use port 3003 in CI environments to resolve port conflicts
• Add dev:ci script for CI-specific Next.js server on port 3003  
• Update Playwright config to automatically detect CI and use appropriate port

## Test plan

- [ ] Verify E2E tests run successfully in CI without port conflicts
- [ ] Confirm local development still uses port 3000
- [ ] Test that Playwright webServer starts correctly in both environments