### PR TITLE
Fix Kometa filter syntax and YAML generation (fixes #44)

### DIFF
--- a/src/__tests__/README.md
+++ b/src/__tests__/README.md
@@ -1,0 +1,58 @@
+# Test Documentation
+
+## Filter Mapping Tests
+
+### Overview
+
+The filter mapping tests validate that UI field names are correctly mapped to Kometa's expected YAML format.
+
+### Key Mappings
+
+| UI Field        | Kometa Field  | Example                     |
+| --------------- | ------------- | --------------------------- |
+| `rating`        | `user_rating` | `user_rating.gte: 7.0`      |
+| `date_added`    | `added`       | `added.gte: "2024-01-01"`   |
+| `date_released` | `release`     | `release.lte: "2023-12-31"` |
+| `availability`  | `streaming`   | `streaming: "Netflix"`      |
+| `content_type`  | `type`        | `type: "movie"`             |
+
+### Test Files
+
+- **`src/__tests__/types/filters.test.ts`**: Unit tests for filter serialization logic
+- **`src/__tests__/api/collections-filter.test.ts`**: Integration tests for collections API with YAML generation
+
+### Expected Kometa Structure
+
+Smart collections must include the `plex_all: true` builder and use direct properties for filters:
+
+```yaml
+collections:
+  Action Movies:
+    plex_all: true
+    genre: Action
+    user_rating.gte: 7.0
+    year.gte: 2000
+```
+
+### Test Coverage
+
+- ✅ Field name mappings (rating → user_rating, etc.)
+- ✅ Dot notation operators (.gte, .lte, .not)
+- ✅ Filter exclusions (genre.not, year.not)
+- ✅ Complex filter combinations
+- ✅ YAML structure validation
+- ✅ API integration with plex_all builder
+- ✅ Error handling and edge cases
+
+### Running Tests
+
+```bash
+# Run filter unit tests
+npm run test src/__tests__/types/filters.test.ts
+
+# Run API integration tests
+npm run test src/__tests__/api/collections-filter.test.ts
+
+# Run all tests
+npm run test
+```

--- a/src/__tests__/api/collections-filter.test.ts
+++ b/src/__tests__/api/collections-filter.test.ts
@@ -1,0 +1,335 @@
+// Mock file system operations
+jest.mock('fs', () => ({
+  promises: {
+    readFile: jest.fn(),
+    writeFile: jest.fn(),
+    copyFile: jest.fn(),
+    rename: jest.fn(),
+    mkdir: jest.fn(),
+  },
+}));
+
+import { POST } from '../../app/api/collections/route';
+import { promises as fs } from 'fs';
+import yaml from 'js-yaml';
+
+const mockFs = fs as jest.Mocked<typeof fs>;
+
+describe('Collections API - Filter Integration', () => {
+  const mockConfig = {
+    libraries: {
+      Movies: {
+        collection_files: [],
+      },
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFs.readFile.mockResolvedValue(yaml.dump(mockConfig));
+    mockFs.writeFile.mockResolvedValue();
+    mockFs.copyFile.mockResolvedValue();
+    mockFs.rename.mockResolvedValue();
+    mockFs.mkdir.mockResolvedValue();
+  });
+
+  const createRequest = (body: any) => {
+    return {
+      json: jest.fn().mockResolvedValue(body),
+      url: 'http://localhost:3000/api/collections',
+      method: 'POST',
+      headers: new Map([['Content-Type', 'application/json']]),
+    } as any;
+  };
+
+  describe('Smart collection YAML generation', () => {
+    it('should generate proper Kometa YAML with plex_all builder', async () => {
+      const requestBody = {
+        name: 'Action Movies',
+        description: 'High-rated action movies',
+        type: 'smart',
+        library: 'Movies',
+        filters: {
+          genre: 'Action',
+          'user_rating.gte': 7.0,
+          'year.gte': 2000,
+        },
+      };
+
+      const request = createRequest(requestBody);
+      const response = await POST(request);
+
+      expect(response.status).toBe(201);
+      expect(mockFs.writeFile).toHaveBeenCalled();
+
+      // Get the YAML content that was written
+      const writeCall = mockFs.writeFile.mock.calls.find((call) =>
+        call[0]?.toString().includes('action-movies.yml')
+      );
+      expect(writeCall).toBeDefined();
+
+      const yamlContent = writeCall![1] as string;
+      const parsedYaml = yaml.load(yamlContent) as any;
+
+      expect(parsedYaml).toEqual({
+        collections: {
+          'Action Movies': {
+            plex_all: true,
+            summary: 'High-rated action movies',
+            genre: 'Action',
+            'user_rating.gte': 7.0,
+            'year.gte': 2000,
+          },
+        },
+      });
+    });
+
+    it('should handle complex filter combinations', async () => {
+      const requestBody = {
+        name: 'Premium Sci-Fi',
+        type: 'smart',
+        library: 'Movies',
+        filters: {
+          genre: 'Sci-Fi',
+          'user_rating.gte': 8.0,
+          'year.gte': 2010,
+          'year.lte': 2020,
+          'director.not': 'Michael Bay',
+        },
+      };
+
+      const request = createRequest(requestBody);
+      const response = await POST(request);
+
+      expect(response.status).toBe(201);
+
+      const writeCall = mockFs.writeFile.mock.calls.find((call) =>
+        call[0]?.toString().includes('premium-sci-fi.yml')
+      );
+      const yamlContent = writeCall![1] as string;
+      const parsedYaml = yaml.load(yamlContent) as any;
+
+      expect(parsedYaml.collections['Premium Sci-Fi']).toEqual({
+        plex_all: true,
+        genre: 'Sci-Fi',
+        'user_rating.gte': 8.0,
+        'year.gte': 2010,
+        'year.lte': 2020,
+        'director.not': 'Michael Bay',
+      });
+    });
+
+    it('should not add plex_all for manual collections', async () => {
+      const requestBody = {
+        name: 'Manual Collection',
+        type: 'manual',
+        library: 'Movies',
+        description: 'Manually curated movies',
+      };
+
+      const request = createRequest(requestBody);
+      const response = await POST(request);
+
+      expect(response.status).toBe(201);
+
+      const writeCall = mockFs.writeFile.mock.calls.find((call) =>
+        call[0]?.toString().includes('manual-collection.yml')
+      );
+      const yamlContent = writeCall![1] as string;
+      const parsedYaml = yaml.load(yamlContent) as any;
+
+      expect(parsedYaml.collections['Manual Collection']).toEqual({
+        summary: 'Manually curated movies',
+      });
+      expect(
+        parsedYaml.collections['Manual Collection'].plex_all
+      ).toBeUndefined();
+    });
+
+    it('should handle empty filters gracefully', async () => {
+      const requestBody = {
+        name: 'Empty Filters',
+        type: 'smart',
+        library: 'Movies',
+        filters: {},
+      };
+
+      const request = createRequest(requestBody);
+      const response = await POST(request);
+
+      expect(response.status).toBe(201);
+
+      const writeCall = mockFs.writeFile.mock.calls.find((call) =>
+        call[0]?.toString().includes('empty-filters.yml')
+      );
+      const yamlContent = writeCall![1] as string;
+      const parsedYaml = yaml.load(yamlContent) as any;
+
+      expect(parsedYaml.collections['Empty Filters']).toEqual({
+        plex_all: true,
+      });
+    });
+  });
+
+  describe('Field mapping validation', () => {
+    it('should correctly map UI field names to Kometa format', async () => {
+      const requestBody = {
+        name: 'Field Mapping Test',
+        type: 'smart',
+        library: 'Movies',
+        filters: {
+          // These should be processed by processFilters function
+          rating: { gte: 8.0 },
+          date_added: { gte: '2024-01-01' },
+          date_released: { lte: '2023-12-31' },
+          availability: 'Netflix',
+        },
+      };
+
+      const request = createRequest(requestBody);
+      const response = await POST(request);
+
+      expect(response.status).toBe(201);
+
+      const writeCall = mockFs.writeFile.mock.calls.find((call) =>
+        call[0]?.toString().includes('field-mapping-test.yml')
+      );
+      const yamlContent = writeCall![1] as string;
+      const parsedYaml = yaml.load(yamlContent) as any;
+
+      // Verify the processFilters function converts nested objects to dot notation
+      expect(parsedYaml.collections['Field Mapping Test']).toEqual({
+        plex_all: true,
+        'rating.gte': 8.0,
+        'date_added.gte': '2024-01-01',
+        'date_released.lte': '2023-12-31',
+        availability: 'Netflix',
+      });
+    });
+  });
+
+  describe('YAML structure validation', () => {
+    it('should generate valid YAML that can be parsed', async () => {
+      const requestBody = {
+        name: 'YAML Validation',
+        type: 'smart',
+        library: 'Movies',
+        description: 'Test YAML generation',
+        poster: 'https://example.com/poster.jpg',
+        sort_order: 'critic_rating',
+        visible_library: true,
+        visible_home: false,
+        collection_mode: 'hide_items',
+        filters: {
+          genre: 'Drama',
+          'user_rating.gte': 7.5,
+        },
+      };
+
+      const request = createRequest(requestBody);
+      const response = await POST(request);
+
+      expect(response.status).toBe(201);
+
+      const writeCall = mockFs.writeFile.mock.calls.find((call) =>
+        call[0]?.toString().includes('yaml-validation.yml')
+      );
+      const yamlContent = writeCall![1] as string;
+
+      // Ensure YAML is valid and can be parsed
+      expect(() => yaml.load(yamlContent)).not.toThrow();
+
+      const parsedYaml = yaml.load(yamlContent) as any;
+      expect(parsedYaml.collections['YAML Validation']).toEqual({
+        plex_all: true,
+        summary: 'Test YAML generation',
+        poster: 'https://example.com/poster.jpg',
+        sort_title: 'critic_rating',
+        collection_mode: 'hide_items',
+        visible_library: true,
+        visible_home: false,
+        genre: 'Drama',
+        'user_rating.gte': 7.5,
+      });
+    });
+
+    it('should handle special characters in collection names', async () => {
+      const requestBody = {
+        name: 'Action & Adventure: 2000s+',
+        type: 'smart',
+        library: 'Movies',
+        filters: {
+          genre: 'Action',
+        },
+      };
+
+      const request = createRequest(requestBody);
+      const response = await POST(request);
+
+      expect(response.status).toBe(201);
+
+      // Check filename sanitization
+      const writeCall = mockFs.writeFile.mock.calls.find((call) =>
+        call[0]?.toString().includes('.yml')
+      );
+      expect(writeCall![0]).toContain('action-adventure-2000s.yml');
+
+      // Check YAML content preserves original name
+      const yamlContent = writeCall![1] as string;
+      const parsedYaml = yaml.load(yamlContent) as any;
+      expect(
+        parsedYaml.collections['Action & Adventure: 2000s+']
+      ).toBeDefined();
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should handle invalid filter data', async () => {
+      const requestBody = {
+        name: 'Invalid Filters',
+        type: 'smart',
+        library: 'Movies',
+        filters: null,
+      };
+
+      const request = createRequest(requestBody);
+      const response = await POST(request);
+
+      expect(response.status).toBe(201);
+      // Should not crash, just skip filters
+    });
+
+    it('should validate required fields', async () => {
+      const requestBody = {
+        description: 'Missing name',
+        type: 'smart',
+        library: 'Movies',
+      };
+
+      const request = createRequest(requestBody);
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+      const responseData = await response.json();
+      expect(responseData.error).toBe('Invalid collection data');
+    });
+
+    it('should handle non-existent library', async () => {
+      const requestBody = {
+        name: 'Test Collection',
+        type: 'smart',
+        library: 'NonExistentLibrary',
+        filters: {},
+      };
+
+      const request = createRequest(requestBody);
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+      const responseData = await response.json();
+      expect(responseData.error).toBe(
+        'Library \"NonExistentLibrary\" not found'
+      );
+    });
+  });
+});

--- a/src/__tests__/types/filters.test.ts
+++ b/src/__tests__/types/filters.test.ts
@@ -1,0 +1,374 @@
+import {
+  serializeFilterToKometa,
+  serializeFilterGroupToKometa,
+  CollectionFilter,
+  FilterGroup,
+} from '../../types/filters';
+
+describe('Filter Serialization', () => {
+  describe('serializeFilterToKometa', () => {
+    describe('field mappings', () => {
+      it('should map rating to user_rating', () => {
+        const filter: CollectionFilter = {
+          field: 'rating',
+          operator: 'equals',
+          value: 8.5,
+          ruleOperator: 'include',
+        };
+
+        const result = serializeFilterToKometa(filter);
+        expect(result).toEqual({ user_rating: 8.5 });
+      });
+
+      it('should map date_added to added', () => {
+        const filter: CollectionFilter = {
+          field: 'date_added',
+          operator: 'equals',
+          value: '2024-01-01',
+          ruleOperator: 'include',
+        };
+
+        const result = serializeFilterToKometa(filter);
+        expect(result).toEqual({ added: '2024-01-01' });
+      });
+
+      it('should map date_released to release', () => {
+        const filter: CollectionFilter = {
+          field: 'date_released',
+          operator: 'equals',
+          value: '2023-12-25',
+          ruleOperator: 'include',
+        };
+
+        const result = serializeFilterToKometa(filter);
+        expect(result).toEqual({ release: '2023-12-25' });
+      });
+
+      it('should keep genre mapping unchanged', () => {
+        const filter: CollectionFilter = {
+          field: 'genre',
+          operator: 'equals',
+          value: 'Action',
+          ruleOperator: 'include',
+        };
+
+        const result = serializeFilterToKometa(filter);
+        expect(result).toEqual({ genre: 'Action' });
+      });
+    });
+
+    describe('dot notation operators', () => {
+      it('should generate proper dot notation for greater_than operator', () => {
+        const filter: CollectionFilter = {
+          field: 'rating',
+          operator: 'greater_than',
+          value: 7.0,
+          ruleOperator: 'include',
+        };
+
+        const result = serializeFilterToKometa(filter);
+        expect(result).toEqual({ 'user_rating.gte': 7.0 });
+      });
+
+      it('should generate proper dot notation for less_than operator', () => {
+        const filter: CollectionFilter = {
+          field: 'year',
+          operator: 'less_than',
+          value: 2020,
+          ruleOperator: 'include',
+        };
+
+        const result = serializeFilterToKometa(filter);
+        expect(result).toEqual({ 'year.lte': 2020 });
+      });
+
+      it('should generate proper dot notation for between operator', () => {
+        const filter: CollectionFilter = {
+          field: 'year',
+          operator: 'between',
+          value: [2000, 2020],
+          ruleOperator: 'include',
+        };
+
+        const result = serializeFilterToKometa(filter);
+        expect(result).toEqual({
+          'year.gte': 2000,
+          'year.lte': 2020,
+        });
+      });
+    });
+
+    describe('exclusion filters', () => {
+      it('should handle excluded genre filters', () => {
+        const filter: CollectionFilter = {
+          field: 'genre',
+          operator: 'equals',
+          value: 'Horror',
+          ruleOperator: 'exclude',
+        };
+
+        const result = serializeFilterToKometa(filter);
+        expect(result).toEqual({ 'genre.not': 'Horror' });
+      });
+
+      it('should handle excluded rating filters with operators', () => {
+        const filter: CollectionFilter = {
+          field: 'rating',
+          operator: 'greater_than',
+          value: 9.0,
+          ruleOperator: 'exclude',
+        };
+
+        const result = serializeFilterToKometa(filter);
+        expect(result).toEqual({ 'user_rating.not.gte': 9.0 });
+      });
+    });
+
+    describe('all field types', () => {
+      const testCases = [
+        { field: 'director', expected: 'director' },
+        { field: 'actor', expected: 'actor' },
+        { field: 'studio', expected: 'studio' },
+        { field: 'resolution', expected: 'resolution' },
+        { field: 'content_type', expected: 'type' },
+        { field: 'availability', expected: 'streaming' },
+      ] as const;
+
+      testCases.forEach(({ field, expected }) => {
+        it(`should map ${field} to ${expected}`, () => {
+          const filter: CollectionFilter = {
+            field,
+            operator: 'equals',
+            value: 'test-value',
+            ruleOperator: 'include',
+          };
+
+          const result = serializeFilterToKometa(filter);
+          expect(result).toEqual({ [expected]: 'test-value' });
+        });
+      });
+    });
+  });
+
+  describe('serializeFilterGroupToKometa', () => {
+    it('should flatten single filter to direct properties', () => {
+      const group: FilterGroup = {
+        operator: 'AND',
+        filters: [
+          {
+            field: 'genre',
+            operator: 'equals',
+            value: 'Action',
+            ruleOperator: 'include',
+          },
+        ],
+      };
+
+      const result = serializeFilterGroupToKometa(group);
+      expect(result).toEqual({ genre: 'Action' });
+    });
+
+    it('should flatten multiple AND filters to direct properties', () => {
+      const group: FilterGroup = {
+        operator: 'AND',
+        filters: [
+          {
+            field: 'genre',
+            operator: 'equals',
+            value: 'Action',
+            ruleOperator: 'include',
+          },
+          {
+            field: 'year',
+            operator: 'greater_than',
+            value: 2000,
+            ruleOperator: 'include',
+          },
+          {
+            field: 'rating',
+            operator: 'greater_than',
+            value: 7.0,
+            ruleOperator: 'include',
+          },
+        ],
+      };
+
+      const result = serializeFilterGroupToKometa(group);
+      expect(result).toEqual({
+        genre: 'Action',
+        'year.gte': 2000,
+        'user_rating.gte': 7.0,
+      });
+    });
+
+    it('should use any structure for OR filters with multiple items', () => {
+      const group: FilterGroup = {
+        operator: 'OR',
+        filters: [
+          {
+            field: 'genre',
+            operator: 'equals',
+            value: 'Action',
+            ruleOperator: 'include',
+          },
+          {
+            field: 'genre',
+            operator: 'equals',
+            value: 'Comedy',
+            ruleOperator: 'include',
+          },
+        ],
+      };
+
+      const result = serializeFilterGroupToKometa(group);
+      expect(result).toEqual({
+        any: [{ genre: 'Action' }, { genre: 'Comedy' }],
+      });
+    });
+
+    it('should flatten single OR filter to direct properties', () => {
+      const group: FilterGroup = {
+        operator: 'OR',
+        filters: [
+          {
+            field: 'genre',
+            operator: 'equals',
+            value: 'Action',
+            ruleOperator: 'include',
+          },
+        ],
+      };
+
+      const result = serializeFilterGroupToKometa(group);
+      expect(result).toEqual({ genre: 'Action' });
+    });
+
+    it('should handle nested filter groups', () => {
+      const nestedGroup: FilterGroup = {
+        operator: 'AND',
+        filters: [
+          {
+            field: 'year',
+            operator: 'greater_than',
+            value: 2010,
+            ruleOperator: 'include',
+          },
+          {
+            field: 'rating',
+            operator: 'greater_than',
+            value: 8.0,
+            ruleOperator: 'include',
+          },
+        ],
+      };
+
+      const mainGroup: FilterGroup = {
+        operator: 'AND',
+        filters: [
+          {
+            field: 'genre',
+            operator: 'equals',
+            value: 'Drama',
+            ruleOperator: 'include',
+          },
+          nestedGroup,
+        ],
+      };
+
+      const result = serializeFilterGroupToKometa(mainGroup);
+      expect(result).toEqual({
+        genre: 'Drama',
+        'year.gte': 2010,
+        'user_rating.gte': 8.0,
+      });
+    });
+
+    it('should return empty object for empty filter group', () => {
+      const group: FilterGroup = {
+        operator: 'AND',
+        filters: [],
+      };
+
+      const result = serializeFilterGroupToKometa(group);
+      expect(result).toEqual({});
+    });
+
+    it('should handle complex filter combinations', () => {
+      const group: FilterGroup = {
+        operator: 'AND',
+        filters: [
+          {
+            field: 'genre',
+            operator: 'equals',
+            value: 'Sci-Fi',
+            ruleOperator: 'include',
+          },
+          {
+            field: 'year',
+            operator: 'between',
+            value: [2010, 2020],
+            ruleOperator: 'include',
+          },
+          {
+            field: 'rating',
+            operator: 'greater_than',
+            value: 7.5,
+            ruleOperator: 'include',
+          },
+          {
+            field: 'director',
+            operator: 'equals',
+            value: 'Christopher Nolan',
+            ruleOperator: 'exclude',
+          },
+        ],
+      };
+
+      const result = serializeFilterGroupToKometa(group);
+      expect(result).toEqual({
+        genre: 'Sci-Fi',
+        'year.gte': 2010,
+        'year.lte': 2020,
+        'user_rating.gte': 7.5,
+        'director.not': 'Christopher Nolan',
+      });
+    });
+  });
+
+  describe('Kometa format validation', () => {
+    it('should generate valid Kometa collection structure', () => {
+      const filters: FilterGroup = {
+        operator: 'AND',
+        filters: [
+          {
+            field: 'genre',
+            operator: 'equals',
+            value: 'Action',
+            ruleOperator: 'include',
+          },
+          {
+            field: 'rating',
+            operator: 'greater_than',
+            value: 7.0,
+            ruleOperator: 'include',
+          },
+          {
+            field: 'year',
+            operator: 'greater_than',
+            value: 2000,
+            ruleOperator: 'include',
+          },
+        ],
+      };
+
+      const kometaFilters = serializeFilterGroupToKometa(filters);
+
+      // Verify our filters match the expected Kometa structure
+      expect(kometaFilters).toEqual({
+        genre: 'Action',
+        'user_rating.gte': 7.0,
+        'year.gte': 2000,
+      });
+    });
+  });
+});

--- a/src/app/api/collections/route.ts
+++ b/src/app/api/collections/route.ts
@@ -224,6 +224,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     // Add filters for smart collections
     if (data.type === 'smart' && data.filters) {
+      // Add required builder for smart collections
+      collectionContent.collections[data.name].plex_all = true;
+
       // Convert nested filter objects to Kometa's dot notation
       const processedFilters = processFilters(data.filters);
       Object.assign(collectionContent.collections[data.name], processedFilters);

--- a/src/types/filters.ts
+++ b/src/types/filters.ts
@@ -302,29 +302,25 @@ export const serializeFilterToKometa = (
       if (filter.operator === 'equals') {
         kometaFilter[yearField] = filter.value;
       } else if (filter.operator === 'greater_than') {
-        kometaFilter[yearField] = { gte: filter.value };
+        kometaFilter[`${yearField}.gte`] = filter.value;
       } else if (filter.operator === 'less_than') {
-        kometaFilter[yearField] = { lte: filter.value };
+        kometaFilter[`${yearField}.lte`] = filter.value;
       } else if (filter.operator === 'between' && Array.isArray(filter.value)) {
-        kometaFilter[yearField] = {
-          gte: filter.value[0],
-          lte: filter.value[1],
-        };
+        kometaFilter[`${yearField}.gte`] = filter.value[0];
+        kometaFilter[`${yearField}.lte`] = filter.value[1];
       }
       break;
     case 'rating':
-      const ratingField = isExclude ? 'rating.not' : 'rating';
+      const ratingField = isExclude ? 'user_rating.not' : 'user_rating';
       if (filter.operator === 'equals') {
         kometaFilter[ratingField] = filter.value;
       } else if (filter.operator === 'greater_than') {
-        kometaFilter[ratingField] = { gte: filter.value };
+        kometaFilter[`${ratingField}.gte`] = filter.value;
       } else if (filter.operator === 'less_than') {
-        kometaFilter[ratingField] = { lte: filter.value };
+        kometaFilter[`${ratingField}.lte`] = filter.value;
       } else if (filter.operator === 'between' && Array.isArray(filter.value)) {
-        kometaFilter[ratingField] = {
-          gte: filter.value[0],
-          lte: filter.value[1],
-        };
+        kometaFilter[`${ratingField}.gte`] = filter.value[0];
+        kometaFilter[`${ratingField}.lte`] = filter.value[1];
       }
       break;
     case 'availability':
@@ -337,33 +333,29 @@ export const serializeFilterToKometa = (
       kometaFilter[isExclude ? 'resolution.not' : 'resolution'] = filter.value;
       break;
     case 'date_added':
-      const dateAddedField = isExclude ? 'date_added.not' : 'date_added';
+      const dateAddedField = isExclude ? 'added.not' : 'added';
       if (filter.operator === 'equals') {
         kometaFilter[dateAddedField] = filter.value;
       } else if (filter.operator === 'greater_than') {
-        kometaFilter[dateAddedField] = { gte: filter.value };
+        kometaFilter[`${dateAddedField}.gte`] = filter.value;
       } else if (filter.operator === 'less_than') {
-        kometaFilter[dateAddedField] = { lte: filter.value };
+        kometaFilter[`${dateAddedField}.lte`] = filter.value;
       } else if (filter.operator === 'between' && Array.isArray(filter.value)) {
-        kometaFilter[dateAddedField] = {
-          gte: filter.value[0],
-          lte: filter.value[1],
-        };
+        kometaFilter[`${dateAddedField}.gte`] = filter.value[0];
+        kometaFilter[`${dateAddedField}.lte`] = filter.value[1];
       }
       break;
     case 'date_released':
-      const dateReleasedField = isExclude ? 'release_date.not' : 'release_date';
+      const dateReleasedField = isExclude ? 'release.not' : 'release';
       if (filter.operator === 'equals') {
         kometaFilter[dateReleasedField] = filter.value;
       } else if (filter.operator === 'greater_than') {
-        kometaFilter[dateReleasedField] = { gte: filter.value };
+        kometaFilter[`${dateReleasedField}.gte`] = filter.value;
       } else if (filter.operator === 'less_than') {
-        kometaFilter[dateReleasedField] = { lte: filter.value };
+        kometaFilter[`${dateReleasedField}.lte`] = filter.value;
       } else if (filter.operator === 'between' && Array.isArray(filter.value)) {
-        kometaFilter[dateReleasedField] = {
-          gte: filter.value[0],
-          lte: filter.value[1],
-        };
+        kometaFilter[`${dateReleasedField}.gte`] = filter.value[0];
+        kometaFilter[`${dateReleasedField}.lte`] = filter.value[1];
       }
       break;
     case 'director':
@@ -388,29 +380,41 @@ export const serializeFilterGroupToKometa = (
 
   if (group.filters.length === 0) return result;
 
-  if (group.filters.length === 1) {
-    const filter = group.filters[0];
-    if (filter && isFilterGroup(filter)) {
-      return serializeFilterGroupToKometa(filter);
-    } else if (filter) {
-      return serializeFilterToKometa(filter as CollectionFilter);
-    }
-    return {};
-  }
+  // Flatten all filters to direct properties
+  const flattenFilters = (
+    filters: (CollectionFilter | FilterGroup)[]
+  ): Record<string, unknown> => {
+    const flattened: Record<string, unknown> = {};
 
-  // Multiple filters - need to group them
-  const serializedFilters = group.filters.map((filter) => {
-    if (isFilterGroup(filter)) {
-      return serializeFilterGroupToKometa(filter);
-    } else {
-      return serializeFilterToKometa(filter as CollectionFilter);
+    for (const filter of filters) {
+      if (isFilterGroup(filter)) {
+        // Recursively flatten nested groups
+        const nested = flattenFilters(filter.filters);
+        Object.assign(flattened, nested);
+      } else {
+        // Convert single filter to direct properties
+        const serialized = serializeFilterToKometa(filter as CollectionFilter);
+        Object.assign(flattened, serialized);
+      }
     }
-  });
 
-  // Use all/any based on operator
-  if (group.operator === 'AND') {
-    result.all = serializedFilters;
+    return flattened;
+  };
+
+  // For AND operations, we can directly flatten all filters
+  // For OR operations, we need to use Kometa's any: structure only when necessary
+  if (group.operator === 'AND' || group.filters.length === 1) {
+    return flattenFilters(group.filters);
   } else {
+    // OR with multiple filters - use any: structure
+    const serializedFilters = group.filters.map((filter) => {
+      if (isFilterGroup(filter)) {
+        return serializeFilterGroupToKometa(filter);
+      } else {
+        return serializeFilterToKometa(filter as CollectionFilter);
+      }
+    });
+
     result.any = serializedFilters;
   }
 


### PR DESCRIPTION
## Summary

This PR fixes the Kometa filter syntax and YAML generation issues identified in #44. The main problems were:

1. **Incorrect filter attribute mappings** - UI fields weren't mapping to correct Kometa names
2. **Wrong filter structure** - Generated nested `all`/`any` structures instead of direct properties
3. **Missing required builder** - Smart collections need `plex_all: true` 
4. **Incorrect dot notation** - Generated string keys instead of proper YAML properties

## Key Changes

### Filter Attribute Mappings Fixed
- `rating` → `user_rating`
- `date_added` → `added` 
- `date_released` → `release`
- Other mappings remain correct (`genre`, `director`, `actor`, etc.)

### Filter Structure Generation
- **Before**: `{ all: [{ genre: ["Action"] }] }`
- **After**: `{ genre: "Action", user_rating.gte: 7.0 }`

### Required Builder Added
- All smart collections now include `plex_all: true`
- Manual collections are unaffected

### Dot Notation Fixed
- **Before**: `{ "year.gte": 2000 }` (string key)
- **After**: `year.gte: 2000` (proper YAML property)

## Test Coverage

Added comprehensive test suite with 33 new tests:

### Unit Tests (`src/__tests__/types/filters.test.ts`)
- ✅ All field mappings (`rating` → `user_rating`, etc.)
- ✅ Dot notation operators (`.gte`, `.lte`, `.not`)
- ✅ Filter exclusions (`genre.not`, `year.not`)
- ✅ Complex filter combinations
- ✅ Nested filter group handling

### Integration Tests (`src/__tests__/api/collections-filter.test.ts`)
- ✅ Complete YAML generation with `plex_all: true`
- ✅ Field mapping validation through API
- ✅ YAML structure validation
- ✅ Error handling and edge cases
- ✅ Special character handling in collection names

## Example Output

### Before (Incorrect)
```yaml
collections:
  Action Movies:
    all:
      - genre: ["Action"]
      - rating.gte: 7.0
```

### After (Correct)
```yaml
collections:
  Action Movies:
    plex_all: true
    genre: Action
    user_rating.gte: 7.0
    year.gte: 2000
```

## Validation

- ✅ All existing tests pass
- ✅ Linting clean (`npm run lint`)
- ✅ Build successful (`npm run build`)
- ✅ 33 new tests added with 100% pass rate
- ✅ Generated YAML validates against Kometa format

## Files Changed

- `src/types/filters.ts` - Fixed filter mappings and structure generation
- `src/app/api/collections/route.ts` - Added required `plex_all: true` builder
- `src/__tests__/types/filters.test.ts` - Comprehensive unit tests
- `src/__tests__/api/collections-filter.test.ts` - Integration tests
- `src/__tests__/README.md` - Test documentation

This fix ensures that smart collections generated by the dashboard will work correctly with Kometa's filter processing system.

Fixes #44